### PR TITLE
only exposing schema items, which can now be custom defined via the `…

### DIFF
--- a/pyramid_orb/services/model.py
+++ b/pyramid_orb/services/model.py
@@ -51,21 +51,8 @@ class ModelService(OrbService):
                 records = method(context=context)
                 return CollectionService(self.request, records, parent=self)
 
-        # lookup regular method
-        method = getattr(self.model, key, None)
-        if method and self.request.method == 'GET':
-            record = self.__record or self.model(self.record_id)
-            return_value = method(record)
-            if isinstance(return_value, orb.Collection):
-                from .collection import CollectionService
-                return CollectionService(self.request, return_value, parent=self, name=key)
-            elif isinstance(return_value, orb.Model):
-                return ModelService(self.request, parent=self, record=return_value)
-            else:
-                from .builtins import PyObjectService
-                return PyObjectService(self.request, return_value, parent=self)
-        else:
-            return ModelService(self.request, self.model, parent=self, record_id=key)
+        # otherwise, return a model based on the id
+        return ModelService(self.request, self.model, parent=self, record_id=key)
 
     def _update(self):
         values, context = get_context(self.request, model=self.model)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
         content = f.read()
         major = re.search('__major__ = (\d+)', content).group(1)
         minor = re.search('__minor__ = (\d+)', content).group(1)
-        rev = re.search('__revision__ = "(dev\d+)"', content).group(1)
+        rev = re.search('__revision__ = "(\d+)"', content).group(1)
         version = '.'.join((major, minor, rev))
 except StandardError:
      version = '0.0.0'
@@ -36,12 +36,12 @@ class tag(Command):
         with open('./pyramid_orb/_version.py', 'w') as f:
             f.write('__major__ = {0}\n'.format(result.group(1)))
             f.write('__minor__ = {0}\n'.format(result.group(2)))
-            f.write('__revision__ = "dev{0}"\n'.format(result.group(3)))
+            f.write('__revision__ = "{0}"\n'.format(result.group(3)))
             f.write('__hash__ = "{0}"'.format(result.group(4)))
 
         # tag this new release version
         if not self.no_tag:
-            version = '.'.join([result.group(1), result.group(2), 'dev' + result.group(3)])
+            version = '.'.join([result.group(1), result.group(2), result.group(3)])
 
             print 'creating git tag:', 'v' + version
 


### PR DESCRIPTION
…orb.virtual` decorator