### PR TITLE
Override pagesize instead of limit

### DIFF
--- a/pyramid_orb/service.py
+++ b/pyramid_orb/service.py
@@ -33,7 +33,7 @@ class OrbService(object):
                         self.request.response.headers['X-Orb-Start'] = str(context.start)
                         self.request.response.headers['X-Orb-Limit'] = str(context.limit)
                         self.request.response.headers['X-Orb-Page-Count'] = str(output.pageCount())
-                        self.request.response.headers['X-Orb-Total-Count'] = str(output.count(page=None, limit=None))
+                        self.request.response.headers['X-Orb-Total-Count'] = str(output.count(page=None, pageSize=None))
 
                     return output
                 else:


### PR DESCRIPTION
Orb.context.limit takes pageSize OR limit, so overriding limit didn't change limit because context.limit was still equal to pagesize. Therefore output.count() always returned the page size if the total count was larger than page count. Instead, if we override page size to none, count() will return correct total count because context.limit will be set to default 1000.  

References TBWB-1936